### PR TITLE
fix: send remaining sentences immediately when end_input() is called

### DIFF
--- a/livekit-agents/livekit/agents/tts/stream_pacer.py
+++ b/livekit-agents/livekit/agents/tts/stream_pacer.py
@@ -73,7 +73,7 @@ class StreamPacerWrapper(SentenceStream):
         if self._audio_emitter._dst_ch.closed:
             # close the stream if the audio emitter is closed
             self._closing = True
-            self._wakeup_event.set()
+        self._wakeup_event.set()  # always wake up to send remaining sentences
 
     async def aclose(self) -> None:
         await self._sent_stream.aclose()
@@ -133,7 +133,7 @@ class StreamPacerWrapper(SentenceStream):
             )
             if first_sentence or (
                 generation_stopped and remaining_audio <= self._options.min_remaining_audio
-            ):
+            ) or (self._input_ended and self._sentences):
                 batch: list[str] = []
                 while self._sentences:
                     batch.append(self._sentences.pop(0))


### PR DESCRIPTION
## Summary

Fixes a bug in `StreamPacerWrapper` where calling `end_input()` did not immediately send remaining buffered sentences to TTS, causing multi-second delays in agent responses.

### The Bug

When `end_input()` is called (indicating the user has finished speaking), the pacer continued to wait based on the `remaining_audio` timer calculation instead of immediately sending all remaining text:

1. **`end_input()` only woke the send task conditionally** - it only called `_wakeup_event.set()` when the audio emitter's destination channel was closed, not when it was still open
2. **Send condition didn't account for input ending** - the send loop only sent text when it was the first sentence or when generation stopped and remaining audio was low

### Example of the Problem

With `min_remaining_audio = 5.0s`:
- t=0.0s: First sentence sent; TTS produces 10s audio
- t=0.5s: Two more sentences queued
- t=0.6s: `end_input()` called while audio emitter is still open
  - `_input_ended = True`, but no wakeup occurs
  - Send task sleeps on timer: `remaining_audio - min_remaining_audio = 10 - 5 = 5s`
- t=5.5s: Next send finally happens

Result: ~5 second delay after user finishes speaking before remaining sentences are synthesized.

## Changes

1. **Always wake the send task on `end_input()`** - moved `_wakeup_event.set()` outside the conditional
2. **Added send condition for ended input** - `(self._input_ended and self._sentences)` triggers immediate sending

### Why this is correct

The purpose of pacing is to:
1. **Reduce waste from interruptions** - not relevant once input ends; we're committed to this response
2. **Send larger chunks for better speech quality** - still respected via `max_text_length` batching

Once input has ended, we know exactly what text needs to be synthesized and there's no benefit to delaying. The `max_text_length` batching is still respected, so we're not bypassing quality optimizations - just the waiting.

## Test plan

- [ ] Verify that when `end_input()` is called with pending sentences, they are sent immediately (within ~1 event loop iteration)
- [ ] Verify that `max_text_length` batching is still respected when input ends
- [ ] Verify normal pacing behavior is unchanged when input has not ended

🤖 Generated with [Claude Code](https://claude.com/claude-code)